### PR TITLE
#2 janky way to draw border for existing windows

### DIFF
--- a/src/border.c
+++ b/src/border.c
@@ -3,19 +3,6 @@
 extern uint32_t g_active_window_color;
 extern uint32_t g_inactive_window_color;
 extern float g_border_width;
-struct border {
-  bool focused;
-  bool needs_redraw;
-
-  CGRect bounds;
-  CGPoint origin;
-
-  uint32_t wid;
-  uint64_t sid;
-  uint32_t target_wid;
-
-  CGContextRef context;
-};
 
 static void border_init(struct border* border) {
   memset(border, 0, sizeof(struct border));
@@ -191,7 +178,7 @@ void borders_init(struct borders* borders) {
   memset(borders, 0, sizeof(struct borders));
 }
 
-void borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid) {
+struct border* borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid) {
   struct border* border = NULL;
 
   for (int i = 0; i < borders->num_borders; i++) {
@@ -204,7 +191,7 @@ void borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid) {
   if (!border) {
     borders->borders = realloc(borders->borders,
                                ++borders->num_borders * sizeof(struct border));
-    border = &borders->borders[borders->num_borders - 1]; 
+    border = &borders->borders[borders->num_borders - 1];
     border_init(border);
   }
 
@@ -212,6 +199,7 @@ void borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid) {
   border->sid = sid;
   border->needs_redraw = true;
   border_draw(&borders->borders[borders->num_borders - 1]);
+  return border;
 }
 
 void borders_remove_border(struct borders* borders, uint32_t wid, uint64_t sid) {

--- a/src/border.h
+++ b/src/border.h
@@ -1,13 +1,27 @@
 #pragma once
 #include "extern.h"
 
+struct border {
+  bool focused;
+  bool needs_redraw;
+
+  CGRect bounds;
+  CGPoint origin;
+
+  uint32_t wid;
+  uint64_t sid;
+  uint32_t target_wid;
+
+  CGContextRef context;
+};
+
 struct borders {
   uint32_t num_borders;
   struct border* borders;
 };
 
 void borders_init(struct borders* borders);
-void borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid);
+struct border* borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid);
 void borders_remove_border(struct borders* borders, uint32_t wid, uint64_t sid);
 void borders_update_border(struct borders* borders, uint32_t wid);
 void borders_window_focus(struct borders* borders, uint32_t wid);

--- a/src/extern.h
+++ b/src/extern.h
@@ -56,5 +56,7 @@ extern uint64_t SLSWindowIteratorGetAttributes(CFTypeRef iterator);
 extern int SLSWindowIteratorGetLevel(CFTypeRef iterator, int32_t index);
 
 extern CFArrayRef SLSCopyManagedDisplays(int cid);
+extern CFArrayRef SLSCopyManagedDisplaySpaces(int cid);
+extern CFStringRef SLSCopyManagedDisplayForWindow(int cid, uint32_t wid);
 extern uint64_t SLSManagedDisplayGetCurrentSpace(int cid, CFStringRef uuid);
 

--- a/src/main.c
+++ b/src/main.c
@@ -44,8 +44,10 @@ int main(int argc, char** argv) {
   }
 
   pid_for_task(mach_task_self(), &g_pid);
+  borders_init(&g_borders);
   windows_init(&g_windows);
   events_register();
+  windows_add_existing_windows(SLSMainConnectionID(), &g_windows, &g_borders);
 
   SLSWindowManagementBridgeSetDelegate(NULL);
   mach_port_t port;

--- a/src/main.c
+++ b/src/main.c
@@ -47,7 +47,6 @@ int main(int argc, char** argv) {
   borders_init(&g_borders);
   windows_init(&g_windows);
   events_register();
-  windows_add_existing_windows(SLSMainConnectionID(), &g_windows, &g_borders);
 
   SLSWindowManagementBridgeSetDelegate(NULL);
   mach_port_t port;
@@ -71,6 +70,7 @@ int main(int argc, char** argv) {
     CFRelease(source);
   }
 
+  windows_add_existing_windows(SLSMainConnectionID(), &g_windows, &g_borders);
   CFRunLoopRun();
 
   return 0;

--- a/src/windows.c
+++ b/src/windows.c
@@ -39,83 +39,99 @@ err:
 }
 
 void windows_add_existing_windows(int cid, struct windows* windows, struct borders* borders) {
-    uint64_t *space_list = NULL;
-    int space_count = 0;
+  uint64_t *space_list = NULL;
+  int space_count = 0;
 
-    CFArrayRef display_spaces_ref = SLSCopyManagedDisplaySpaces(cid);
-    if (display_spaces_ref) {
-        int display_spaces_count = CFArrayGetCount(display_spaces_ref);
-        for (int i = 0; i < display_spaces_count; ++i) {
-            CFDictionaryRef display_ref = CFArrayGetValueAtIndex(display_spaces_ref, i);
-            CFArrayRef spaces_ref = CFDictionaryGetValue(display_ref, CFSTR("Spaces"));
-            int spaces_count = CFArrayGetCount(spaces_ref);
+  CFArrayRef display_spaces_ref = SLSCopyManagedDisplaySpaces(cid);
+  if (display_spaces_ref) {
+    int display_spaces_count = CFArrayGetCount(display_spaces_ref);
+    for (int i = 0; i < display_spaces_count; ++i) {
+      CFDictionaryRef display_ref
+                               = CFArrayGetValueAtIndex(display_spaces_ref, i);
+      CFArrayRef spaces_ref = CFDictionaryGetValue(display_ref,
+                                                   CFSTR("Spaces"));
+      int spaces_count = CFArrayGetCount(spaces_ref);
 
-            space_list = (uint64_t*)realloc(space_list, sizeof(uint64_t)*(space_count + spaces_count));
+      space_list = (uint64_t*)realloc(space_list,
+                                      sizeof(uint64_t)*(space_count
+                                                        + spaces_count));
 
-            for (int j = 0; j < spaces_count; ++j) {
-                CFDictionaryRef space_ref = CFArrayGetValueAtIndex(spaces_ref, j);
-                CFNumberRef sid_ref = CFDictionaryGetValue(space_ref, CFSTR("id64"));
-                CFNumberGetValue(sid_ref, CFNumberGetType(sid_ref), space_list + space_count + j);
-            }
-            space_count += spaces_count;
-        }
-        CFRelease(display_spaces_ref);
+      for (int j = 0; j < spaces_count; ++j) {
+        CFDictionaryRef space_ref = CFArrayGetValueAtIndex(spaces_ref, j);
+        CFNumberRef sid_ref = CFDictionaryGetValue(space_ref, CFSTR("id64"));
+        CFNumberGetValue(sid_ref,
+                         CFNumberGetType(sid_ref),
+                         space_list + space_count + j);
+      }
+      space_count += spaces_count;
     }
+    CFRelease(display_spaces_ref);
+  }
 
-    uint64_t set_tags = 1;
-    uint64_t clear_tags = 0;
-    uint32_t options = 0x2;
+  uint64_t set_tags = 1;
+  uint64_t clear_tags = 0;
+  uint32_t options = 0x2;
 
-    CFArrayRef space_list_ref = cfarray_of_cfnumbers(space_list, sizeof(uint64_t), space_count, kCFNumberSInt64Type);
-    CFArrayRef window_list_ref = SLSCopyWindowsWithOptionsAndTags(cid, 0, space_list_ref, options, &set_tags, &clear_tags);
-    if (!window_list_ref) goto err;
+  CFArrayRef space_list_ref = cfarray_of_cfnumbers(space_list,
+                                                   sizeof(uint64_t),
+                                                   space_count,
+                                                   kCFNumberSInt64Type);
 
-    int count = CFArrayGetCount(window_list_ref);
-    if (!count) goto out;
+  CFArrayRef window_list_ref = SLSCopyWindowsWithOptionsAndTags(cid,
+                                                                0,
+                                                                space_list_ref,
+                                                                options,
+                                                                &set_tags,
+                                                                &clear_tags  );
+  if (!window_list_ref) goto err;
 
-    CFTypeRef query = SLSWindowQueryWindows(cid, window_list_ref, count);
-    CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
+  int count = CFArrayGetCount(window_list_ref);
+  if (!count) goto out;
 
-    while (SLSWindowIteratorAdvance(iterator)) {
-        uint64_t tags = SLSWindowIteratorGetTags(iterator);
-        uint64_t attributes = SLSWindowIteratorGetAttributes(iterator);
-        uint32_t parent_wid = SLSWindowIteratorGetParentID(iterator);
-        uint32_t wid = SLSWindowIteratorGetWindowID(iterator);
-        uint64_t sid = window_space_id(cid, wid);
+  CFTypeRef query = SLSWindowQueryWindows(cid, window_list_ref, count);
+  CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
 
-          if (((parent_wid == 0)
-               && ((attributes & 0x2)
-                   || (tags & 0x400000000000000))
-               && (((tags & 0x1))
-                    || ((tags & 0x2)
-                        && (tags & 0x80000000))))) {
-            windows_add_window(windows, wid);
-            SLSRequestNotificationsForWindows(cid,
-                                              windows->wids,
-                                              windows->num_windows);
-            struct border* border = borders_add_border(borders, wid, sid);
-            if (g_first_time) {
-              g_first_time = false;
-              borders_remove_border(borders, wid, sid);
-              border = borders_add_border(borders, wid, sid);
-            }
-            CFArrayRef border_ref = cfarray_of_cfnumbers(&border->wid,
-                                                         sizeof(uint32_t),
-                                                         1,
-                                                         kCFNumberSInt32Type);
-            border->sid = sid;
-            SLSMoveWindowsToManagedSpace(cid, border_ref, sid);
-            CFRelease(border_ref);
-        }
+  while (SLSWindowIteratorAdvance(iterator)) {
+    uint64_t tags = SLSWindowIteratorGetTags(iterator);
+    uint64_t attributes = SLSWindowIteratorGetAttributes(iterator);
+    uint32_t parent_wid = SLSWindowIteratorGetParentID(iterator);
+    uint32_t wid = SLSWindowIteratorGetWindowID(iterator);
+    uint64_t sid = window_space_id(cid, wid);
+
+    if (((parent_wid == 0)
+          && ((attributes & 0x2)
+            || (tags & 0x400000000000000))
+          && (((tags & 0x1))
+            || ((tags & 0x2)
+              && (tags & 0x80000000))))) {
+      windows_add_window(windows, wid);
+      SLSRequestNotificationsForWindows(cid,
+          windows->wids,
+          windows->num_windows);
+      struct border* border = borders_add_border(borders, wid, sid);
+      if (g_first_time) {
+        g_first_time = false;
+        borders_remove_border(borders, wid, sid);
+        border = borders_add_border(borders, wid, sid);
+      }
+      CFArrayRef border_ref = cfarray_of_cfnumbers(&border->wid,
+                                                   sizeof(uint32_t),
+                                                   1,
+                                                   kCFNumberSInt32Type);
+
+      border->sid = sid;
+      SLSMoveWindowsToManagedSpace(cid, border_ref, sid);
+      CFRelease(border_ref);
     }
+  }
 
-    CFRelease(query);
-    CFRelease(iterator);
+  CFRelease(query);
+  CFRelease(iterator);
 out:
-    CFRelease(window_list_ref);
+  CFRelease(window_list_ref);
 err:
-    CFRelease(space_list_ref);
-    free(space_list);
+  CFRelease(space_list_ref);
+  free(space_list);
 }
 
 void windows_add_window(struct windows* windows, uint32_t wid) {

--- a/src/windows.c
+++ b/src/windows.c
@@ -1,8 +1,121 @@
 #include "windows.h"
 #include <string.h>
 
+extern bool g_first_time;
+
 void windows_init(struct windows* windows) {
   memset(windows, 0, sizeof(struct windows));
+}
+
+static uint64_t window_space_id(int cid, uint32_t wid)
+{
+    uint64_t sid = 0;
+
+    CFArrayRef window_list_ref = cfarray_of_cfnumbers(&wid, sizeof(uint32_t), 1, kCFNumberSInt32Type);
+    CFArrayRef space_list_ref = SLSCopySpacesForWindows(cid, 0x7, window_list_ref);
+    if (!space_list_ref) goto err;
+
+    int count = CFArrayGetCount(space_list_ref);
+    if (!count) goto free;
+
+    CFNumberRef id_ref = CFArrayGetValueAtIndex(space_list_ref, 0);
+    CFNumberGetValue(id_ref, CFNumberGetType(id_ref), &sid);
+
+free:
+    CFRelease(space_list_ref);
+err:
+    CFRelease(window_list_ref);
+
+    if (sid) return sid;
+
+    CFStringRef uuid = SLSCopyManagedDisplayForWindow(cid, wid);
+    if (uuid) {
+        uint64_t sid = SLSManagedDisplayGetCurrentSpace(cid, uuid);
+        CFRelease(uuid);
+        return sid;
+    }
+
+    return 0;
+}
+
+void windows_add_existing_windows(int cid, struct windows* windows, struct borders* borders) {
+    uint64_t *space_list = NULL;
+    int space_count = 0;
+
+    CFArrayRef display_spaces_ref = SLSCopyManagedDisplaySpaces(cid);
+    if (display_spaces_ref) {
+        int display_spaces_count = CFArrayGetCount(display_spaces_ref);
+        for (int i = 0; i < display_spaces_count; ++i) {
+            CFDictionaryRef display_ref = CFArrayGetValueAtIndex(display_spaces_ref, i);
+            CFArrayRef spaces_ref = CFDictionaryGetValue(display_ref, CFSTR("Spaces"));
+            int spaces_count = CFArrayGetCount(spaces_ref);
+
+            space_list = (uint64_t*)realloc(space_list, sizeof(uint64_t)*(space_count + spaces_count));
+
+            for (int j = 0; j < spaces_count; ++j) {
+                CFDictionaryRef space_ref = CFArrayGetValueAtIndex(spaces_ref, j);
+                CFNumberRef sid_ref = CFDictionaryGetValue(space_ref, CFSTR("id64"));
+                CFNumberGetValue(sid_ref, CFNumberGetType(sid_ref), space_list + space_count + j);
+            }
+            space_count += spaces_count;
+        }
+        CFRelease(display_spaces_ref);
+    }
+
+    uint64_t set_tags = 1;
+    uint64_t clear_tags = 0;
+    uint32_t options = 0x2;
+
+    CFArrayRef space_list_ref = cfarray_of_cfnumbers(space_list, sizeof(uint64_t), space_count, kCFNumberSInt64Type);
+    CFArrayRef window_list_ref = SLSCopyWindowsWithOptionsAndTags(cid, 0, space_list_ref, options, &set_tags, &clear_tags);
+    if (!window_list_ref) goto err;
+
+    int count = CFArrayGetCount(window_list_ref);
+    if (!count) goto out;
+
+    CFTypeRef query = SLSWindowQueryWindows(cid, window_list_ref, count);
+    CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
+
+    while (SLSWindowIteratorAdvance(iterator)) {
+        uint64_t tags = SLSWindowIteratorGetTags(iterator);
+        uint64_t attributes = SLSWindowIteratorGetAttributes(iterator);
+        uint32_t parent_wid = SLSWindowIteratorGetParentID(iterator);
+        uint32_t wid = SLSWindowIteratorGetWindowID(iterator);
+        uint64_t sid = window_space_id(cid, wid);
+
+          if (((parent_wid == 0)
+               && ((attributes & 0x2)
+                   || (tags & 0x400000000000000))
+               && (((tags & 0x1))
+                    || ((tags & 0x2)
+                        && (tags & 0x80000000))))) {
+            windows_add_window(windows, wid);
+            SLSRequestNotificationsForWindows(cid,
+                                              windows->wids,
+                                              windows->num_windows);
+            struct border* border = borders_add_border(borders, wid, sid);
+            if (g_first_time) {
+              g_first_time = false;
+              borders_remove_border(borders, wid, sid);
+              border = borders_add_border(borders, wid, sid);
+            }
+            CFArrayRef border_ref = cfarray_of_cfnumbers(&border->wid,
+                                                         sizeof(uint32_t),
+                                                         1,
+                                                         kCFNumberSInt32Type);
+            border->sid = sid;
+            SLSMoveWindowsToManagedSpace(cid, border_ref, sid);
+            CFRelease(border_ref);
+        }
+    }
+
+    CFRelease(query);
+    CFRelease(iterator);
+out:
+    CFRelease(window_list_ref);
+err:
+    CFRelease(space_list_ref);
+    free(space_list);
 }
 
 void windows_add_window(struct windows* windows, uint32_t wid) {

--- a/src/windows.h
+++ b/src/windows.h
@@ -8,5 +8,6 @@ struct windows {
 };
 
 void windows_init(struct windows* windows);
+void windows_add_existing_windows(int cid, struct windows* windows, struct borders* borders);
 void windows_add_window(struct windows* windows, uint32_t wid);
 bool windows_remove_window(struct windows* windows, uint32_t wid);


### PR DESCRIPTION
Janky solution for https://github.com/FelixKratz/JankyBorders/issues/2
Reads window ids of all spaces upon launch and creates a border for them, moving that border to the space that the window is on.

Ignores minimized windows and hidden applications. I believe these should be handled by a designated handler/event, but this code can probably be tweaked to include them if wanted.

Might be bugs, code is kinda quickly put together, so indentation and structure is terrible -- sorry for that.
Feel free to use it as you please and rewrite instead of merging this PR.