### PR TITLE
Use hashtable for storage

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 all: | bin
-	clang -std=c99 -O3 -g src/main.c src/events.c src/windows.c src/border.c -o bin/borders -framework AppKit -F/System/Library/PrivateFrameworks/ -framework SkyLight
+	clang -std=c99 -O3 -g src/main.c src/hashtable.c src/events.c src/windows.c src/border.c -o bin/borders -framework AppKit -F/System/Library/PrivateFrameworks/ -framework SkyLight
 
 debug:
-	clang -std=c99 -O0 -g src/main.c src/events.c src/windows.c src/border.c -o bin/debug -framework AppKit -F/System/Library/PrivateFrameworks/ -framework SkyLight
+	clang -std=c99 -O0 -g src/main.c src/hashtable.c src/events.c src/windows.c src/border.c -o bin/debug -framework AppKit -F/System/Library/PrivateFrameworks/ -framework SkyLight
 
 bin:
 	mkdir bin

--- a/src/border.c
+++ b/src/border.c
@@ -191,7 +191,7 @@ struct border* border_create(uint32_t wid, uint64_t sid) {
   return border;
 }
 
-void borders_remove_border(uint32_t wid, uint64_t sid) {
+void borders_remove_border(uint32_t wid) {
   struct border* border = table_find(&g_windows, &wid);
   if (border) {
     table_remove(&g_windows, &wid);

--- a/src/border.c
+++ b/src/border.c
@@ -184,14 +184,6 @@ struct border* border_create(uint32_t wid, uint64_t sid) {
   return border;
 }
 
-void borders_remove_border(uint32_t wid) {
-  struct border* border = table_find(&g_windows, &wid);
-  if (border) {
-    table_remove(&g_windows, &wid);
-    border_destroy(border);
-  }
-}
-
 void borders_update_border(uint32_t wid) {
   struct border* border = table_find(&g_windows, &wid);
   if (border) {

--- a/src/border.c
+++ b/src/border.c
@@ -1,5 +1,6 @@
 #include "border.h"
 #include "hashtable.h"
+#include "windows.h"
 
 extern uint32_t g_active_window_color;
 extern uint32_t g_inactive_window_color;
@@ -61,6 +62,7 @@ static void border_draw(struct border* border) {
   int level = SLSWindowIteratorGetLevel(iterator, 0);
   CFRelease(iterator);
   CFRelease(query);
+  CFRelease(target_ref);
 
   int sub_level = 0;
   SLSGetWindowSubLevel(cid, border->target_wid, &sub_level);
@@ -99,17 +101,8 @@ static void border_draw(struct border* border) {
     CFRelease(frame_region);
 
     if (!border->sid) {
-      CFArrayRef spaces = SLSCopySpacesForWindows(cid, 0x2, target_ref);
-      if (CFArrayGetCount(spaces) > 0) {
-        CFNumberRef number = CFArrayGetValueAtIndex(spaces, 0);
-        uint64_t sid;
-        CFNumberGetValue(number, CFNumberGetType(number), &sid);
-        border->sid = sid;
-        CFRelease(number);
-      }
-      CFRelease(spaces);
+      border->sid = window_space_id(cid, border->target_wid);
     }
-    CFRelease(target_ref);
 
     CFArrayRef window_list = cfarray_of_cfnumbers(&border->wid,
                                                   sizeof(uint32_t),

--- a/src/border.c
+++ b/src/border.c
@@ -175,10 +175,6 @@ void border_hide(struct border* border) {
 }
 
 void border_unhide(struct border* border) {
-  if (!border->wid) border_draw(border);
-  else {
-    int cid = SLSMainConnectionID();
-    SLSOrderWindow(cid, border->wid, -1, border->target_wid);
-  }
+  border_draw(border);
 }
 

--- a/src/border.c
+++ b/src/border.c
@@ -208,23 +208,23 @@ void borders_update_border(uint32_t wid) {
 
 void borders_window_focus(uint32_t wid) {
   for (int window_index = 0; window_index < g_windows.capacity; ++window_index) {
-    struct bucket *bucket = g_windows.buckets[window_index];
+    struct bucket* bucket = g_windows.buckets[window_index];
     while (bucket) {
       if (bucket->value) {
-          struct border* border = bucket->value;
-          if (border->focused && border->target_wid != wid) {
-            border->focused = false;
+        struct border* border = bucket->value;
+        if (border->focused && border->target_wid != wid) {
+          border->focused = false;
+          border->needs_redraw = true;
+          border_draw(border);
+        }
+
+        if (border->target_wid == wid) {
+          if (!border->focused) {
+            border->focused = true;
             border->needs_redraw = true;
             border_draw(border);
           }
-
-          if (border->target_wid == wid) {
-            if (!border->focused) {
-              border->focused = true;
-              border->needs_redraw = true;
-              border_draw(border);
-            }
-          }
+        }
       }
 
       bucket = bucket->next;

--- a/src/border.c
+++ b/src/border.c
@@ -33,6 +33,7 @@ void border_move(struct border* border) {
 
 void border_draw(struct border* border) {
   int cid = SLSMainConnectionID();
+  if (!is_space_visible(cid, border->sid)) return;
 
   bool shown = false;
   SLSWindowIsOrderedIn(cid, border->target_wid, &shown);

--- a/src/border.h
+++ b/src/border.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "extern.h"
+#include "hashtable.h"
 
 struct border {
   bool focused;
@@ -15,17 +16,12 @@ struct border {
   CGContextRef context;
 };
 
-struct borders {
-  uint32_t num_borders;
-  struct border* borders;
-};
-
-void borders_init(struct borders* borders);
-struct border* borders_add_border(struct borders* borders, uint32_t wid, uint64_t sid);
-void borders_remove_border(struct borders* borders, uint32_t wid, uint64_t sid);
-void borders_update_border(struct borders* borders, uint32_t wid);
-void borders_window_focus(struct borders* borders, uint32_t wid);
-void borders_move_border(struct borders* borders, uint32_t wid);
+void borders_remove_border(uint32_t wid, uint64_t sid);
+void borders_update_border(uint32_t wid);
+void borders_window_focus(uint32_t wid);
+void borders_move_border(uint32_t wid);
+struct border* border_create(uint32_t wid, uint64_t sid);
+void border_destroy(struct border* border);
 
 uint32_t get_front_window();
 

--- a/src/border.h
+++ b/src/border.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "extern.h"
+#include "helpers.h"
 #include "hashtable.h"
 
 struct border {
@@ -16,28 +16,10 @@ struct border {
   CGContextRef context;
 };
 
-void borders_update_border(uint32_t wid);
-void borders_window_focus(uint32_t wid);
-void borders_move_border(uint32_t wid);
-struct border* border_create(uint32_t wid, uint64_t sid);
+void border_init(struct border* border);
+void border_unhide(struct border* border);
+void border_hide(struct border* border);
+void border_move(struct border* border);
+void border_draw(struct border* border);
+
 void border_destroy(struct border* border);
-
-uint32_t get_front_window();
-
-static inline  CFArrayRef cfarray_of_cfnumbers(void* values, size_t size, int count, CFNumberType type) {
-  CFNumberRef temp[count];
-
-  for (int i = 0; i < count; ++i) {
-    temp[i] = CFNumberCreate(NULL, type, ((char *)values) + (size * i));
-  }
-
-  CFArrayRef result = CFArrayCreate(NULL,
-                                    (const void **)temp,
-                                    count,
-                                    &kCFTypeArrayCallBacks);
-
-  for (int i = 0; i < count; ++i) CFRelease(temp[i]);
-
-  return result;
-}
-

--- a/src/border.h
+++ b/src/border.h
@@ -16,7 +16,7 @@ struct border {
   CGContextRef context;
 };
 
-void borders_remove_border(uint32_t wid, uint64_t sid);
+void borders_remove_border(uint32_t wid);
 void borders_update_border(uint32_t wid);
 void borders_window_focus(uint32_t wid);
 void borders_move_border(uint32_t wid);

--- a/src/border.h
+++ b/src/border.h
@@ -27,6 +27,8 @@ void borders_update_border(struct borders* borders, uint32_t wid);
 void borders_window_focus(struct borders* borders, uint32_t wid);
 void borders_move_border(struct borders* borders, uint32_t wid);
 
+uint32_t get_front_window();
+
 static inline  CFArrayRef cfarray_of_cfnumbers(void* values, size_t size, int count, CFNumberType type) {
   CFNumberRef temp[count];
 

--- a/src/border.h
+++ b/src/border.h
@@ -16,7 +16,6 @@ struct border {
   CGContextRef context;
 };
 
-void borders_remove_border(uint32_t wid);
 void borders_update_border(uint32_t wid);
 void borders_window_focus(uint32_t wid);
 void borders_move_border(uint32_t wid);

--- a/src/events.c
+++ b/src/events.c
@@ -90,10 +90,16 @@ static void window_modify_handler(uint32_t event, void* data, size_t data_length
     borders_window_focus(wid);
   } else if (event == EVENT_WINDOW_UNHIDE) {
     printf("Window Unhide: %d\n", wid);
-    border_create(wid, window_space_id(cid, wid));
+    struct border *border = table_find(&g_windows, &wid);
+    if (border) {
+      SLSOrderWindow(cid, border->wid, -1, border->target_wid);
+    }
   } else if (event == EVENT_WINDOW_HIDE) {
     printf("Window Hide: %d\n", wid);
-    borders_remove_border(wid);
+    struct border *border = table_find(&g_windows, &wid);
+    if (border) {
+      SLSOrderWindow(cid, border->wid, 0, border->target_wid);
+    }
   }
 }
 

--- a/src/events.c
+++ b/src/events.c
@@ -58,7 +58,7 @@ static void window_spawn_handler(uint32_t event, void* data, size_t data_length,
   } else if (event == EVENT_WINDOW_DESTROY) {
     printf("Window Destroyed: %d\n", wid);
     if (windows_remove_window(&g_windows, wid, sid)) {
-        update_window_notifications();
+      update_window_notifications();
     }
 
     borders_window_focus(get_front_window());

--- a/src/events.c
+++ b/src/events.c
@@ -99,6 +99,10 @@ static void window_modify_handler(uint32_t event, void* data, size_t data_length
   }
 }
 
+static void space_handler(uint32_t event, void* data, size_t data_length, void* context) {
+  windows_draw_borders_on_current_spaces(&g_windows);
+}
+
 void events_register() {
   int cid = SLSMainConnectionID();
   void* cid_ctx = (void*)(intptr_t)cid;
@@ -113,6 +117,8 @@ void events_register() {
   SLSRegisterNotifyProc(window_modify_handler, EVENT_WINDOW_UPDATE, cid_ctx);
   SLSRegisterNotifyProc(window_spawn_handler, EVENT_WINDOW_CREATE, cid_ctx);
   SLSRegisterNotifyProc(window_spawn_handler, EVENT_WINDOW_DESTROY, cid_ctx);
+
+  SLSRegisterNotifyProc(space_handler, EVENT_SPACE_CHANGE, cid_ctx);
 
   // for (int i = 0; i < 2000; i++) {
   //   SLSRegisterNotifyProc(event_watcher, i, NULL);

--- a/src/events.c
+++ b/src/events.c
@@ -57,8 +57,8 @@ static void window_spawn_handler(uint32_t event, void* data, size_t data_length,
     CFRelease(target_ref);
   } else if (event == EVENT_WINDOW_DESTROY) {
     printf("Window Destroyed: %d\n", wid);
-    if (windows_remove_window(&g_windows, wid)) {
-            update_window_notifications();
+    if (windows_remove_window(&g_windows, wid, sid)) {
+        update_window_notifications();
     }
 
     borders_window_focus(get_front_window());
@@ -93,7 +93,7 @@ static void window_modify_handler(uint32_t event, void* data, size_t data_length
     windows_add_window(&g_windows, wid, window_space_id(cid, wid));
   } else if (event == EVENT_WINDOW_HIDE) {
     printf("Window Hide: %d\n", wid);
-    borders_remove_border(wid, 0);
+    borders_remove_border(wid);
   }
 }
 

--- a/src/events.c
+++ b/src/events.c
@@ -83,6 +83,7 @@ static void window_modify_handler(uint32_t event, void* data, size_t data_length
     usleep(10000);
 
     windows_window_focus(windows, get_front_window());
+    windows_window_update(windows, wid);
   } else if (event == EVENT_WINDOW_LEVEL) {
     printf("Window Level: %d\n", wid);
     windows_window_update(windows, wid);

--- a/src/events.h
+++ b/src/events.h
@@ -14,4 +14,6 @@
 #define EVENT_WINDOW_CREATE  1325
 #define EVENT_WINDOW_DESTROY 1326
 
+#define EVENT_SPACE_CHANGE   1401
+
 void events_register();

--- a/src/extern.h
+++ b/src/extern.h
@@ -1,6 +1,7 @@
 #include <CoreGraphics/CoreGraphics.h>
 
 extern int SLSMainConnectionID();
+extern CGError SLSWindowManagementBridgeSetDelegate(void* delegate);
 extern CGError SLSGetEventPort(int cid, mach_port_t* port_out);
 extern CGEventRef SLEventCreateNextEvent(int cid);
 extern void _CFMachPortSetOptions(CFMachPortRef mach_port, int options);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2,113 +2,104 @@
 #include <stdlib.h>
 #include <string.h>
 
-void table_init(struct table *table, int capacity, table_hash_func hash, table_compare_func cmp)
-{
-    table->count = 0;
-    table->capacity = capacity;
-    table->max_load = 0.75f;
-    table->hash = hash;
-    table->cmp = cmp;
-    table->buckets = malloc(sizeof(struct bucket *) * capacity);
-    memset(table->buckets, 0, sizeof(struct bucket *) * capacity);
+void table_init(struct table *table, int capacity, table_hash_func hash, table_compare_func cmp) {
+  table->count = 0;
+  table->capacity = capacity;
+  table->max_load = 0.75f;
+  table->hash = hash;
+  table->cmp = cmp;
+  table->buckets = malloc(sizeof(struct bucket *) * capacity);
+  memset(table->buckets, 0, sizeof(struct bucket *) * capacity);
 }
 
-void table_free(struct table *table)
-{
-    for (int i = 0; i < table->capacity; ++i) {
-        struct bucket *next, *bucket = table->buckets[i];
-        while (bucket) {
-            next = bucket->next;
-            free(bucket->key);
-            free(bucket);
-            bucket = next;
-        }
+void table_free(struct table *table) {
+  for (int i = 0; i < table->capacity; ++i) {
+    struct bucket *next, *bucket = table->buckets[i];
+    while (bucket) {
+      next = bucket->next;
+      free(bucket->key);
+      free(bucket);
+      bucket = next;
     }
+  }
 
-    if (table->buckets) {
-        free(table->buckets);
-        table->buckets = NULL;
-    }
+  if (table->buckets) {
+    free(table->buckets);
+    table->buckets = NULL;
+  }
 }
 
-struct bucket **
-table_get_bucket(struct table *table, void *key)
-{
-    struct bucket **bucket = table->buckets + (table->hash(key) % table->capacity);
-    while (*bucket) {
-        if (table->cmp((*bucket)->key, key)) {
-            break;
-        }
-        bucket = &(*bucket)->next;
+struct bucket** table_get_bucket(struct table *table, void *key) {
+  struct bucket** bucket = table->buckets + (table->hash(key) % table->capacity);
+  while (*bucket) {
+    if (table->cmp((*bucket)->key, key)) {
+      break;
     }
-    return bucket;
+    bucket = &(*bucket)->next;
+  }
+  return bucket;
 }
 
-void
-table_rehash(struct table *table)
-{
-    struct bucket **old_buckets = table->buckets;
-    int old_capacity = table->capacity;
+void table_rehash(struct table *table) {
+  struct bucket **old_buckets = table->buckets;
+  int old_capacity = table->capacity;
 
-    table->count = 0;
-    table->capacity = 2 * table->capacity;
-    table->buckets = malloc(sizeof(struct bucket *) * table->capacity);
-    memset(table->buckets, 0, sizeof(struct bucket *) * table->capacity);
+  table->count = 0;
+  table->capacity = 2 * table->capacity;
+  table->buckets = malloc(sizeof(struct bucket *) * table->capacity);
+  memset(table->buckets, 0, sizeof(struct bucket *) * table->capacity);
 
-    for (int i = 0; i < old_capacity; ++i) {
-        struct bucket *next_bucket, *old_bucket = old_buckets[i];
-        while (old_bucket) {
-            struct bucket **new_bucket = table_get_bucket(table, old_bucket->key);
-            *new_bucket = malloc(sizeof(struct bucket));
-            (*new_bucket)->key = old_bucket->key;
-            (*new_bucket)->value = old_bucket->value;
-            (*new_bucket)->next = NULL;
-            ++table->count;
-            next_bucket = old_bucket->next;
-            free(old_bucket);
-            old_bucket = next_bucket;
-        }
+  for (int i = 0; i < old_capacity; ++i) {
+    struct bucket *next_bucket, *old_bucket = old_buckets[i];
+    while (old_bucket) {
+      struct bucket **new_bucket = table_get_bucket(table, old_bucket->key);
+      *new_bucket = malloc(sizeof(struct bucket));
+      (*new_bucket)->key = old_bucket->key;
+      (*new_bucket)->value = old_bucket->value;
+      (*new_bucket)->next = NULL;
+      ++table->count;
+      next_bucket = old_bucket->next;
+      free(old_bucket);
+      old_bucket = next_bucket;
     }
+  }
 
-    free(old_buckets);
+  free(old_buckets);
 }
 
-void _table_add(struct table *table, void *key, int key_size, void *value)
-{
-    struct bucket **bucket = table_get_bucket(table, key);
-    if (*bucket) {
-        if (!(*bucket)->value) {
-            (*bucket)->value = value;
-        }
-    } else {
-        *bucket = malloc(sizeof(struct bucket));
-        (*bucket)->key = malloc(key_size);
-        (*bucket)->value = value;
-        memcpy((*bucket)->key, key, key_size);
-        (*bucket)->next = NULL;
-        ++table->count;
-
-        float load = (1.0f * table->count) / table->capacity;
-        if (load > table->max_load) {
-            table_rehash(table);
-        }
+void _table_add(struct table* table, void* key, int key_size, void* value) {
+  struct bucket** bucket = table_get_bucket(table, key);
+  if (*bucket) {
+    if (!(*bucket)->value) {
+      (*bucket)->value = value;
     }
+  } else {
+    *bucket = malloc(sizeof(struct bucket));
+    (*bucket)->key = malloc(key_size);
+    (*bucket)->value = value;
+    memcpy((*bucket)->key, key, key_size);
+    (*bucket)->next = NULL;
+    ++table->count;
+
+    float load = (1.0f * table->count) / table->capacity;
+    if (load > table->max_load) {
+      table_rehash(table);
+    }
+  }
 }
 
-void table_remove(struct table *table, void *key)
-{
-    struct bucket *next, **bucket = table_get_bucket(table, key);
-    if (*bucket) {
-        free((*bucket)->key);
-        next = (*bucket)->next;
-        free(*bucket);
-        *bucket = next;
-        --table->count;
-    }
+void table_remove(struct table* table, void* key) {
+  struct bucket *next, **bucket = table_get_bucket(table, key);
+  if (*bucket) {
+    free((*bucket)->key);
+    next = (*bucket)->next;
+    free(*bucket);
+    *bucket = next;
+    --table->count;
+  }
 }
 
-void *table_find(struct table *table, void *key)
-{
-    struct bucket *bucket = *table_get_bucket(table, key);
-    return bucket ? bucket->value : NULL;
+void *table_find(struct table* table, void* key) {
+  struct bucket* bucket = *table_get_bucket(table, key);
+  return bucket ? bucket->value : NULL;
 }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1,0 +1,114 @@
+#include "hashtable.h"
+#include <stdlib.h>
+#include <string.h>
+
+void table_init(struct table *table, int capacity, table_hash_func hash, table_compare_func cmp)
+{
+    table->count = 0;
+    table->capacity = capacity;
+    table->max_load = 0.75f;
+    table->hash = hash;
+    table->cmp = cmp;
+    table->buckets = malloc(sizeof(struct bucket *) * capacity);
+    memset(table->buckets, 0, sizeof(struct bucket *) * capacity);
+}
+
+void table_free(struct table *table)
+{
+    for (int i = 0; i < table->capacity; ++i) {
+        struct bucket *next, *bucket = table->buckets[i];
+        while (bucket) {
+            next = bucket->next;
+            free(bucket->key);
+            free(bucket);
+            bucket = next;
+        }
+    }
+
+    if (table->buckets) {
+        free(table->buckets);
+        table->buckets = NULL;
+    }
+}
+
+struct bucket **
+table_get_bucket(struct table *table, void *key)
+{
+    struct bucket **bucket = table->buckets + (table->hash(key) % table->capacity);
+    while (*bucket) {
+        if (table->cmp((*bucket)->key, key)) {
+            break;
+        }
+        bucket = &(*bucket)->next;
+    }
+    return bucket;
+}
+
+void
+table_rehash(struct table *table)
+{
+    struct bucket **old_buckets = table->buckets;
+    int old_capacity = table->capacity;
+
+    table->count = 0;
+    table->capacity = 2 * table->capacity;
+    table->buckets = malloc(sizeof(struct bucket *) * table->capacity);
+    memset(table->buckets, 0, sizeof(struct bucket *) * table->capacity);
+
+    for (int i = 0; i < old_capacity; ++i) {
+        struct bucket *next_bucket, *old_bucket = old_buckets[i];
+        while (old_bucket) {
+            struct bucket **new_bucket = table_get_bucket(table, old_bucket->key);
+            *new_bucket = malloc(sizeof(struct bucket));
+            (*new_bucket)->key = old_bucket->key;
+            (*new_bucket)->value = old_bucket->value;
+            (*new_bucket)->next = NULL;
+            ++table->count;
+            next_bucket = old_bucket->next;
+            free(old_bucket);
+            old_bucket = next_bucket;
+        }
+    }
+
+    free(old_buckets);
+}
+
+void _table_add(struct table *table, void *key, int key_size, void *value)
+{
+    struct bucket **bucket = table_get_bucket(table, key);
+    if (*bucket) {
+        if (!(*bucket)->value) {
+            (*bucket)->value = value;
+        }
+    } else {
+        *bucket = malloc(sizeof(struct bucket));
+        (*bucket)->key = malloc(key_size);
+        (*bucket)->value = value;
+        memcpy((*bucket)->key, key, key_size);
+        (*bucket)->next = NULL;
+        ++table->count;
+
+        float load = (1.0f * table->count) / table->capacity;
+        if (load > table->max_load) {
+            table_rehash(table);
+        }
+    }
+}
+
+void table_remove(struct table *table, void *key)
+{
+    struct bucket *next, **bucket = table_get_bucket(table, key);
+    if (*bucket) {
+        free((*bucket)->key);
+        next = (*bucket)->next;
+        free(*bucket);
+        *bucket = next;
+        --table->count;
+    }
+}
+
+void *table_find(struct table *table, void *key)
+{
+    struct bucket *bucket = *table_get_bucket(table, key);
+    return bucket ? bucket->value : NULL;
+}

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -1,0 +1,34 @@
+#ifndef HASHTABLE_H
+#define HASHTABLE_H
+
+#define TABLE_HASH_FUNC(name) unsigned long name(void *key)
+typedef TABLE_HASH_FUNC(table_hash_func);
+
+#define TABLE_COMPARE_FUNC(name) int name(void *key_a, void *key_b)
+typedef TABLE_COMPARE_FUNC(table_compare_func);
+
+struct bucket
+{
+    void *key;
+    void *value;
+    struct bucket *next;
+};
+struct table
+{
+    int count;
+    int capacity;
+    float max_load;
+    table_hash_func *hash;
+    table_compare_func *cmp;
+    struct bucket **buckets;
+};
+
+void table_init(struct table *table, int capacity, table_hash_func hash, table_compare_func cmp);
+void table_free(struct table *table);
+
+#define table_add(table, key, value) _table_add(table, key, sizeof(*key), value)
+void _table_add(struct table *table, void *key, int key_size, void *value);
+void table_remove(struct table *table, void *key);
+void *table_find(struct table *table, void *key);
+
+#endif

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -1,34 +1,34 @@
 #ifndef HASHTABLE_H
 #define HASHTABLE_H
 
-#define TABLE_HASH_FUNC(name) unsigned long name(void *key)
+#define TABLE_HASH_FUNC(name) unsigned long name(void* key)
 typedef TABLE_HASH_FUNC(table_hash_func);
 
-#define TABLE_COMPARE_FUNC(name) int name(void *key_a, void *key_b)
+#define TABLE_COMPARE_FUNC(name) int name(void* key_a, void* key_b)
 typedef TABLE_COMPARE_FUNC(table_compare_func);
 
 struct bucket
 {
-    void *key;
-    void *value;
-    struct bucket *next;
+  void* key;
+  void* value;
+  struct bucket* next;
 };
 struct table
 {
-    int count;
-    int capacity;
-    float max_load;
-    table_hash_func *hash;
-    table_compare_func *cmp;
-    struct bucket **buckets;
+  int count;
+  int capacity;
+  float max_load;
+  table_hash_func* hash;
+  table_compare_func* cmp;
+  struct bucket** buckets;
 };
 
-void table_init(struct table *table, int capacity, table_hash_func hash, table_compare_func cmp);
-void table_free(struct table *table);
+void table_init(struct table* table, int capacity, table_hash_func hash, table_compare_func cmp);
+void table_free(struct table* table);
 
 #define table_add(table, key, value) _table_add(table, key, sizeof(*key), value)
-void _table_add(struct table *table, void *key, int key_size, void *value);
-void table_remove(struct table *table, void *key);
-void *table_find(struct table *table, void *key);
+void _table_add(struct table* table, void* key, int key_size, void *value);
+void table_remove(struct table* table, void* key);
+void* table_find(struct table* table, void* key);
 
 #endif

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -1,0 +1,106 @@
+#include "extern.h"
+
+static inline  CFArrayRef cfarray_of_cfnumbers(void* values, size_t size, int count, CFNumberType type) {
+  CFNumberRef temp[count];
+
+  for (int i = 0; i < count; ++i) {
+    temp[i] = CFNumberCreate(NULL, type, ((char *)values) + (size * i));
+  }
+
+  CFArrayRef result = CFArrayCreate(NULL,
+                                    (const void **)temp,
+                                    count,
+                                    &kCFTypeArrayCallBacks);
+
+  for (int i = 0; i < count; ++i) CFRelease(temp[i]);
+
+  return result;
+}
+
+static inline uint32_t get_front_window() {
+  int cid = SLSMainConnectionID();
+  ProcessSerialNumber psn;
+  _SLPSGetFrontProcess(&psn);
+  int target_cid;
+  SLSGetConnectionIDForPSN(cid, &psn, &target_cid);
+
+  CFArrayRef displays = SLSCopyManagedDisplays(cid);
+  uint32_t space_count = CFArrayGetCount(displays);
+  uint64_t space_list[space_count];
+
+  for (int i = 0; i < space_count; i++) {
+    space_list[i] = SLSManagedDisplayGetCurrentSpace(cid,
+                             (CFStringRef)CFArrayGetValueAtIndex(displays, i));
+  }
+
+  CFRelease(displays);
+
+  CFArrayRef space_list_ref = cfarray_of_cfnumbers(space_list,
+                                                   sizeof(uint64_t),
+                                                   space_count,
+                                                   kCFNumberSInt64Type);
+
+  uint64_t set_tags = 1;
+  uint64_t clear_tags = 0;
+  CFArrayRef window_list = SLSCopyWindowsWithOptionsAndTags(cid,
+                                                            target_cid,
+                                                            space_list_ref,
+                                                            0x2,
+                                                            &set_tags,
+                                                            &clear_tags    );
+
+  uint32_t wid = 0;
+  if (window_list) {
+    uint32_t window_count = CFArrayGetCount(window_list);
+    CFTypeRef query = SLSWindowQueryWindows(cid, window_list, window_count);
+    if (query) {
+      CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
+      if (iterator) {
+        wid = SLSWindowIteratorGetWindowID(iterator);
+        CFRelease(iterator);
+      }
+      CFRelease(query);
+    }
+    CFRelease(window_list);
+  }
+
+  CFRelease(space_list_ref);
+  return wid;
+}
+
+static inline uint64_t window_space_id(int cid, uint32_t wid) {
+  uint64_t sid = 0;
+
+  CFArrayRef window_list_ref = cfarray_of_cfnumbers(&wid,
+                                                    sizeof(uint32_t),
+                                                    1,
+                                                    kCFNumberSInt32Type);
+
+  CFArrayRef space_list_ref = SLSCopySpacesForWindows(cid,
+                                                      0x7,
+                                                      window_list_ref);
+
+
+  if (space_list_ref) {
+    int count = CFArrayGetCount(space_list_ref);
+    if (count > 0) {
+      CFNumberRef id_ref = (CFNumberRef)CFArrayGetValueAtIndex(space_list_ref,
+                                                               0             );
+      CFNumberGetValue(id_ref, CFNumberGetType(id_ref), &sid);
+    }
+    CFRelease(space_list_ref);
+  }
+  CFRelease(window_list_ref);
+
+  if (sid) return sid;
+
+  CFStringRef uuid = SLSCopyManagedDisplayForWindow(cid, wid);
+  if (uuid) {
+    uint64_t sid = SLSManagedDisplayGetCurrentSpace(cid, uuid);
+    CFRelease(uuid);
+    return sid;
+  }
+
+  return 0;
+}
+

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -68,6 +68,22 @@ static inline uint32_t get_front_window() {
   return wid;
 }
 
+static inline bool is_space_visible(int cid, uint64_t sid) {
+  CFArrayRef displays = SLSCopyManagedDisplays(cid);
+  uint32_t space_count = CFArrayGetCount(displays);
+
+  for (int i = 0; i < space_count; i++) {
+    if (sid == SLSManagedDisplayGetCurrentSpace(cid,
+                           (CFStringRef)CFArrayGetValueAtIndex(displays, i))) {
+      CFRelease(displays);
+      return true;
+    }
+  }
+
+  CFRelease(displays);
+  return false;
+}
+
 static inline uint64_t window_space_id(int cid, uint32_t wid) {
   uint64_t sid = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,6 @@ void callback(CFMachPortRef port, void* message, CFIndex size, void* context) {
   } while (event != NULL);
 }
 
-extern CGError SLSWindowManagementBridgeSetDelegate(void* delegate);
 int main(int argc, char** argv) {
   if (argc == 4) {
     if (sscanf(argv[1], "active_color=0x%x", &g_active_window_color) != 1) {
@@ -79,7 +78,7 @@ int main(int argc, char** argv) {
     CFRelease(source);
   }
 
-  windows_add_existing_windows(SLSMainConnectionID(), &g_windows);
+  windows_add_existing_windows(&g_windows);
   CFRunLoopRun();
 
   return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -11,12 +11,12 @@ struct table g_windows;
 
 static TABLE_HASH_FUNC(hash_windows)
 {
-    return *(uint32_t *) key;
+  return *(uint32_t *) key;
 }
 
 static TABLE_COMPARE_FUNC(cmp_windows)
 {
-    return *(uint32_t *) key_a == *(uint32_t *) key_b;
+  return *(uint32_t *) key_a == *(uint32_t *) key_b;
 }
 
 void callback(CFMachPortRef port, void* message, CFIndex size, void* context) {

--- a/src/windows.c
+++ b/src/windows.c
@@ -146,7 +146,7 @@ void windows_add_existing_windows(struct table* windows) {
       while (SLSWindowIteratorAdvance(iterator)) {
         ITERATOR_WINDOW_SUITABLE(iterator, {
           uint32_t wid = SLSWindowIteratorGetWindowID(iterator);
-          windows_window_create(windows, wid, 0);
+          windows_window_create(windows, wid, window_space_id(cid, wid));
         });
       }
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -5,52 +5,39 @@ void windows_init(struct windows* windows) {
   memset(windows, 0, sizeof(struct windows));
 }
 
-static void windows_add_border_to_current_space(struct windows* windows, struct borders* borders) {
-  int cid = SLSMainConnectionID();
-  CFArrayRef displays = SLSCopyManagedDisplays(cid);
-  uint32_t space_count = CFArrayGetCount(displays);
-  uint64_t space_list[space_count];
+static uint64_t window_space_id(int cid, uint32_t wid) {
+  uint64_t sid = 0;
 
-  for (int i = 0; i < space_count; i++) {
-    space_list[i] = SLSManagedDisplayGetCurrentSpace(cid,
-                                          CFArrayGetValueAtIndex(displays, i));
-  }
+  CFArrayRef window_list_ref = cfarray_of_cfnumbers(&wid,
+                                                    sizeof(uint32_t),
+                                                    1,
+                                                    kCFNumberSInt32Type);
 
-  CFRelease(displays);
+  CFArrayRef space_list_ref = SLSCopySpacesForWindows(cid,
+                                                      0x7,
+                                                      window_list_ref);
 
-  CFArrayRef space_list_ref = cfarray_of_cfnumbers(space_list,
-                                                   sizeof(uint64_t),
-                                                   space_count,
-                                                   kCFNumberSInt64Type);
 
-  uint64_t set_tags = 1;
-  uint64_t clear_tags = 0;
-  CFArrayRef window_list = SLSCopyWindowsWithOptionsAndTags(cid,
-                                                            0,
-                                                            space_list_ref,
-                                                            0x2,
-                                                            &set_tags,
-                                                            &clear_tags    );
-
-  if (window_list) {
-    uint32_t window_count = CFArrayGetCount(window_list);
-    CFTypeRef query = SLSWindowQueryWindows(cid, window_list, window_count);
-    if (query) {
-      CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
-      if (iterator) {
-        while(SLSWindowIteratorAdvance(iterator)) {
-          ITERATOR_WINDOW_SUITABLE(iterator, {
-            uint32_t wid = SLSWindowIteratorGetWindowID(iterator);
-            borders_add_border(borders, wid, 0);
-          });
-        }
-      }
-      CFRelease(query);
+  if (space_list_ref) {
+    int count = CFArrayGetCount(space_list_ref);
+    if (count > 0) {
+      CFNumberRef id_ref = CFArrayGetValueAtIndex(space_list_ref, 0);
+      CFNumberGetValue(id_ref, CFNumberGetType(id_ref), &sid);
     }
-    CFRelease(window_list);
+    CFRelease(space_list_ref);
+  }
+  CFRelease(window_list_ref);
+
+  if (sid) return sid;
+
+  CFStringRef uuid = SLSCopyManagedDisplayForWindow(cid, wid);
+  if (uuid) {
+    uint64_t sid = SLSManagedDisplayGetCurrentSpace(cid, uuid);
+    CFRelease(uuid);
+    return sid;
   }
 
-  CFRelease(space_list_ref);
+  return 0;
 }
 
 void windows_add_existing_windows(int cid, struct windows* windows, struct borders* borders) {
@@ -106,7 +93,17 @@ void windows_add_existing_windows(int cid, struct windows* windows, struct borde
       while (SLSWindowIteratorAdvance(iterator)) {
         ITERATOR_WINDOW_SUITABLE(iterator, {
           uint32_t wid = SLSWindowIteratorGetWindowID(iterator);
+          uint64_t sid = window_space_id(cid, wid);
           windows_add_window(windows, wid);
+          struct border* border = borders_add_border(borders, wid, sid);
+          CFArrayRef border_ref = cfarray_of_cfnumbers(&border->wid,
+                                                       sizeof(uint32_t),
+                                                       1,
+                                                       kCFNumberSInt32Type);
+
+          border->sid = sid;
+          SLSMoveWindowsToManagedSpace(cid, border_ref, sid);
+          CFRelease(border_ref);
         });
       }
 
@@ -114,15 +111,14 @@ void windows_add_existing_windows(int cid, struct windows* windows, struct borde
                                         windows->wids,
                                         windows->num_windows);
 
+
       CFRelease(query);
       CFRelease(iterator);
     }
     CFRelease(window_list_ref);
   }
-
   CFRelease(space_list_ref);
   free(space_list);
-  windows_add_border_to_current_space(windows, borders);
 }
 
 void windows_add_window(struct windows* windows, uint32_t wid) {
@@ -146,55 +142,4 @@ bool windows_remove_window(struct windows* windows, uint32_t wid) {
     }
   }
   return false;
-}
-
-uint32_t get_front_window() {
-  int cid = SLSMainConnectionID();
-  ProcessSerialNumber psn;
-  _SLPSGetFrontProcess(&psn);
-  int target_cid;
-  SLSGetConnectionIDForPSN(cid, &psn, &target_cid);
-
-  CFArrayRef displays = SLSCopyManagedDisplays(cid);
-  uint32_t space_count = CFArrayGetCount(displays);
-  uint64_t space_list[space_count];
-
-  for (int i = 0; i < space_count; i++) {
-    space_list[i] = SLSManagedDisplayGetCurrentSpace(cid,
-                                          CFArrayGetValueAtIndex(displays, i));
-  }
-
-  CFRelease(displays);
-
-  CFArrayRef space_list_ref = cfarray_of_cfnumbers(space_list,
-                                                   sizeof(uint64_t),
-                                                   space_count,
-                                                   kCFNumberSInt64Type);
-
-  uint64_t set_tags = 1;
-  uint64_t clear_tags = 0;
-  CFArrayRef window_list = SLSCopyWindowsWithOptionsAndTags(cid,
-                                                            target_cid,
-                                                            space_list_ref,
-                                                            0x2,
-                                                            &set_tags,
-                                                            &clear_tags    );
-
-  uint32_t wid = 0;
-  if (window_list) {
-    uint32_t window_count = CFArrayGetCount(window_list);
-    CFTypeRef query = SLSWindowQueryWindows(cid, window_list, window_count);
-    if (query) {
-      CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
-      if (iterator) {
-        wid = SLSWindowIteratorGetWindowID(iterator);
-        CFRelease(iterator);
-      }
-      CFRelease(query);
-    }
-    CFRelease(window_list);
-  }
-
-  CFRelease(space_list_ref);
-  return wid;
 }

--- a/src/windows.c
+++ b/src/windows.c
@@ -141,9 +141,9 @@ struct border* windows_add_window(struct table* windows, uint32_t wid, uint64_t 
     return border;
 }
 
-bool windows_remove_window(struct table* windows, uint32_t wid) {
+bool windows_remove_window(struct table* windows, uint32_t wid, uint64_t sid) {
   struct border *border = table_find(windows, &wid);
-  if (border) {
+  if (border && border->sid == sid) {
     table_remove(windows, &wid);
     border_destroy(border);
     return true;

--- a/src/windows.h
+++ b/src/windows.h
@@ -26,3 +26,4 @@ void windows_window_create(struct table* windows, uint32_t wid, uint64_t sid);
 bool windows_window_destroy(struct table* windows, uint32_t wid, uint32_t sid);
 void windows_add_existing_windows(struct table* windows);
 void windows_update_notifications(struct table* windows);
+void windows_draw_borders_on_current_spaces(struct table* windows);

--- a/src/windows.h
+++ b/src/windows.h
@@ -20,5 +20,5 @@
 void windows_add_existing_windows(int cid, struct table* windows);
 uint64_t window_space_id(int cid, uint32_t wid);
 struct border* windows_add_window(struct table* windows, uint32_t wid, uint64_t sid);
-bool windows_remove_window(struct table* windows, uint32_t wid);
+bool windows_remove_window(struct table* windows, uint32_t wid, uint64_t sid);
 void update_window_notifications(void);

--- a/src/windows.h
+++ b/src/windows.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdlib.h>
 #include "border.h"
+#include "hashtable.h"
 
 #define ITERATOR_WINDOW_SUITABLE(iterator, code) { \
   uint64_t tags = SLSWindowIteratorGetTags(iterator); \
@@ -16,12 +17,8 @@
   } \
 }
 
-struct windows {
-  uint32_t num_windows;
-  uint32_t* wids;
-};
-
-void windows_init(struct windows* windows);
-void windows_add_existing_windows(int cid, struct windows* windows, struct borders* borders);
-void windows_add_window(struct windows* windows, uint32_t wid);
-bool windows_remove_window(struct windows* windows, uint32_t wid);
+void windows_add_existing_windows(int cid, struct table* windows);
+uint64_t window_space_id(int cid, uint32_t wid);
+struct border* windows_add_window(struct table* windows, uint32_t wid, uint64_t sid);
+bool windows_remove_window(struct table* windows, uint32_t wid);
+void update_window_notifications(void);

--- a/src/windows.h
+++ b/src/windows.h
@@ -25,6 +25,3 @@ void windows_init(struct windows* windows);
 void windows_add_existing_windows(int cid, struct windows* windows, struct borders* borders);
 void windows_add_window(struct windows* windows, uint32_t wid);
 bool windows_remove_window(struct windows* windows, uint32_t wid);
-
-uint32_t get_front_window();
-

--- a/src/windows.h
+++ b/src/windows.h
@@ -21,3 +21,5 @@ void windows_add_existing_windows(int cid, struct table* windows);
 uint64_t window_space_id(int cid, uint32_t wid);
 bool windows_remove_window(struct table* windows, uint32_t wid, uint64_t sid);
 void update_window_notifications(void);
+
+uint64_t window_space_id(int cid, uint32_t wid);

--- a/src/windows.h
+++ b/src/windows.h
@@ -17,9 +17,12 @@
   } \
 }
 
-void windows_add_existing_windows(int cid, struct table* windows);
-uint64_t window_space_id(int cid, uint32_t wid);
-bool windows_remove_window(struct table* windows, uint32_t wid, uint64_t sid);
-void update_window_notifications(void);
-
-uint64_t window_space_id(int cid, uint32_t wid);
+void windows_window_update(struct table* windows, uint32_t wid);
+void windows_window_focus(struct table* windows, uint32_t wid);
+void windows_window_hide(struct table* windows, uint32_t wid);
+void windows_window_unhide(struct table* windows, uint32_t wid);
+void windows_window_move(struct table* windows, uint32_t wid);
+void windows_window_create(struct table* windows, uint32_t wid, uint64_t sid);
+bool windows_window_destroy(struct table* windows, uint32_t wid, uint32_t sid);
+void windows_add_existing_windows(struct table* windows);
+void windows_update_notifications(struct table* windows);


### PR DESCRIPTION
Uses hashtable for storage instead of having separate tracked arrays for windows and borders.
Also fixes bug mentioned in #6 