### PR TITLE
feat: Add gradient borders

### DIFF
--- a/src/border.c
+++ b/src/border.c
@@ -130,6 +130,27 @@ void border_draw(struct border* border) {
                                                           NULL          );
 
       CGContextAddPath(border->context, stroke_path);
+      CGColorRef c[2];
+      int color1 = 0xff5c8f96;
+      int color2 = 0xffc27674;
+      float r1 = ((color1 >> 16) & 0xff) / 255.f;
+      float g1 = ((color1 >> 8) & 0xff) / 255.f;
+      float b1 = ((color1 >> 0) & 0xff) / 255.f;
+      float a1 = ((color1 >> 24) & 0xff) / 255.f;
+      float r2 = ((color2 >> 16) & 0xff) / 255.f;
+      float g2 = ((color2 >> 8) & 0xff) / 255.f;
+      float b2 = ((color2 >> 0) & 0xff) / 255.f;
+      float a2 = ((color2 >> 24) & 0xff) / 255.f;
+      c[0] = CGColorCreateSRGB(r1, g1, b1, a1);
+      c[1] = CGColorCreateSRGB(r2, g2, b2, a2);
+      CFArrayRef cfc = CFArrayCreate(NULL, (const void **)c, 2, &kCFTypeArrayCallBacks);
+      CGGradientRef grad = CGGradientCreateWithColors(NULL, cfc, NULL);
+
+      CGContextReplacePathWithStrokedPath(border->context);
+      CGContextClip(border->context);
+      CGPoint other_corner = CGPointMake(frame.size.width, frame.size.height);
+      CGContextDrawLinearGradient(border->context, grad, CGPointZero, other_corner, 0);
+
       CGContextStrokePath(border->context);
       CFRelease(stroke_path);
     }

--- a/src/border.h
+++ b/src/border.h
@@ -11,21 +11,24 @@
 #define BORDER_UPDATE_MASK_ALL      (BORDER_UPDATE_MASK_ACTIVE \
                                      | BORDER_UPDATE_MASK_INACTIVE)
 
-typedef struct window_style {
-  enum { GRADIENT, SOLID } stype;
-  union style {
-    struct gradient {
-      uint32_t color1;
-      uint32_t color2;
-      enum { TOPLEFT_BOTTOMRIGHT, TOPRIGHT_BOTTOMLEFT } direction;
-    } gradient;
+struct gradient {
+  enum { TL_TO_BR, TR_TO_BL } direction;
+  uint32_t color1;
+  uint32_t color2;
+};
+
+struct color_style {
+  enum { COLOR_STYLE_GRADIENT, COLOR_STYLE_SOLID } stype;
+  union {
     uint32_t color;
-  } style;
-} window_style;
+    struct gradient gradient;
+  };
+};
 
 struct settings {
-  window_style active_window;
-  window_style inactive_window;
+  struct color_style active_window;
+  struct color_style inactive_window;
+
   float border_width;
   char border_style;
 };

--- a/src/border.h
+++ b/src/border.h
@@ -11,9 +11,21 @@
 #define BORDER_UPDATE_MASK_ALL      (BORDER_UPDATE_MASK_ACTIVE \
                                      | BORDER_UPDATE_MASK_INACTIVE)
 
+typedef struct window_style {
+  enum { GRADIENT, SOLID } stype;
+  union style {
+    struct gradient {
+      uint32_t color1;
+      uint32_t color2;
+      enum { TOPLEFT_BOTTOMRIGHT, TOPRIGHT_BOTTOMLEFT } direction;
+    } gradient;
+    uint32_t color;
+  } style;
+} window_style;
+
 struct settings {
-  uint32_t active_window_color;
-  uint32_t inactive_window_color;
+  window_style active_window;
+  window_style inactive_window;
   float border_width;
   char border_style;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -7,8 +7,10 @@
 pid_t g_pid;
 struct table g_windows;
 struct mach_server g_mach_server;
-struct settings g_settings = { .active_window_color = 0xffe1e3e4,
-                               .inactive_window_color = 0xff494d64,
+struct settings g_settings = { .active_window = { .stype = SOLID,
+                                                  .style.color = 0xffe1e3e4 },
+                               .inactive_window = { .stype = SOLID,
+                                                    .style.color =  0xff494d64 },
                                .border_width = 4.f,
                                .border_style = BORDER_STYLE_ROUND  };
 
@@ -35,12 +37,46 @@ static uint32_t parse_settings(struct settings* settings, int count, char** argu
   for (int i = 0; i < count; i++) {
     if (sscanf(arguments[i],
                "active_color=0x%x",
-               &settings->active_window_color) == 1) {
+               &settings->active_window.style.color) == 1) {
+      settings->active_window.stype = SOLID;
+      update_mask |= BORDER_UPDATE_MASK_ACTIVE;
+    }
+    else if (sscanf(arguments[i],
+             "active_color=gradient(top_left=0x%x,bottom_right=0x%x)",
+             &settings->active_window.style.gradient.color1,
+             &settings->active_window.style.gradient.color2) == 2) {
+      settings->active_window.stype = GRADIENT;
+      settings->active_window.style.gradient.direction = TOPLEFT_BOTTOMRIGHT;
+      update_mask |= BORDER_UPDATE_MASK_ACTIVE;
+    }
+    else if (sscanf(arguments[i],
+             "active_color=gradient(top_right=0x%x,bottom_left=0x%x)",
+             &settings->active_window.style.gradient.color1,
+             &settings->active_window.style.gradient.color2) == 2) {
+      settings->active_window.stype = GRADIENT;
+      settings->active_window.style.gradient.direction = TOPRIGHT_BOTTOMLEFT;
       update_mask |= BORDER_UPDATE_MASK_ACTIVE;
     }
     else if (sscanf(arguments[i],
              "inactive_color=0x%x",
-             &settings->inactive_window_color) == 1) {
+             &settings->inactive_window.style.color) == 1) {
+      settings->inactive_window.stype = SOLID;
+      update_mask |= BORDER_UPDATE_MASK_INACTIVE;
+    }
+    else if (sscanf(arguments[i],
+             "inactive_color=gradient(top_left=0x%x,bottom_right=0x%x)",
+             &settings->inactive_window.style.gradient.color1,
+             &settings->inactive_window.style.gradient.color2) == 2) {
+      settings->inactive_window.stype = GRADIENT;
+      settings->inactive_window.style.gradient.direction = TOPLEFT_BOTTOMRIGHT;
+      update_mask |= BORDER_UPDATE_MASK_INACTIVE;
+    }
+    else if (sscanf(arguments[i],
+             "inactive_color=gradient(top_right=0x%x,bottom_left=0x%x)",
+             &settings->inactive_window.style.gradient.color1,
+             &settings->inactive_window.style.gradient.color2) == 2) {
+      settings->inactive_window.stype = GRADIENT;
+      settings->inactive_window.style.gradient.direction = TOPRIGHT_BOTTOMLEFT;
       update_mask |= BORDER_UPDATE_MASK_INACTIVE;
     }
     else if (sscanf(arguments[i], "width=%f", &settings->border_width) == 1) {

--- a/src/main.c
+++ b/src/main.c
@@ -7,10 +7,10 @@
 pid_t g_pid;
 struct table g_windows;
 struct mach_server g_mach_server;
-struct settings g_settings = { .active_window = { .stype = SOLID,
-                                                  .style.color = 0xffe1e3e4 },
-                               .inactive_window = { .stype = SOLID,
-                                                    .style.color =  0xff494d64 },
+struct settings g_settings = { .active_window = { .stype = COLOR_STYLE_SOLID,
+                                                  .color = 0xffe1e3e4 },
+                               .inactive_window = { .stype = COLOR_STYLE_SOLID,
+                                                    .color =  0xff494d64 },
                                .border_width = 4.f,
                                .border_style = BORDER_STYLE_ROUND  };
 
@@ -37,46 +37,46 @@ static uint32_t parse_settings(struct settings* settings, int count, char** argu
   for (int i = 0; i < count; i++) {
     if (sscanf(arguments[i],
                "active_color=0x%x",
-               &settings->active_window.style.color) == 1) {
-      settings->active_window.stype = SOLID;
+               &settings->active_window.color) == 1) {
+      settings->active_window.stype = COLOR_STYLE_SOLID;
       update_mask |= BORDER_UPDATE_MASK_ACTIVE;
     }
     else if (sscanf(arguments[i],
              "active_color=gradient(top_left=0x%x,bottom_right=0x%x)",
-             &settings->active_window.style.gradient.color1,
-             &settings->active_window.style.gradient.color2) == 2) {
-      settings->active_window.stype = GRADIENT;
-      settings->active_window.style.gradient.direction = TOPLEFT_BOTTOMRIGHT;
+             &settings->active_window.gradient.color1,
+             &settings->active_window.gradient.color2) == 2) {
+      settings->active_window.stype = COLOR_STYLE_GRADIENT;
+      settings->active_window.gradient.direction = TL_TO_BR;
       update_mask |= BORDER_UPDATE_MASK_ACTIVE;
     }
     else if (sscanf(arguments[i],
              "active_color=gradient(top_right=0x%x,bottom_left=0x%x)",
-             &settings->active_window.style.gradient.color1,
-             &settings->active_window.style.gradient.color2) == 2) {
-      settings->active_window.stype = GRADIENT;
-      settings->active_window.style.gradient.direction = TOPRIGHT_BOTTOMLEFT;
+             &settings->active_window.gradient.color1,
+             &settings->active_window.gradient.color2) == 2) {
+      settings->active_window.stype = COLOR_STYLE_GRADIENT;
+      settings->active_window.gradient.direction = TR_TO_BL;
       update_mask |= BORDER_UPDATE_MASK_ACTIVE;
     }
     else if (sscanf(arguments[i],
              "inactive_color=0x%x",
-             &settings->inactive_window.style.color) == 1) {
-      settings->inactive_window.stype = SOLID;
+             &settings->inactive_window.color) == 1) {
+      settings->inactive_window.stype = COLOR_STYLE_SOLID;
       update_mask |= BORDER_UPDATE_MASK_INACTIVE;
     }
     else if (sscanf(arguments[i],
              "inactive_color=gradient(top_left=0x%x,bottom_right=0x%x)",
-             &settings->inactive_window.style.gradient.color1,
-             &settings->inactive_window.style.gradient.color2) == 2) {
-      settings->inactive_window.stype = GRADIENT;
-      settings->inactive_window.style.gradient.direction = TOPLEFT_BOTTOMRIGHT;
+             &settings->inactive_window.gradient.color1,
+             &settings->inactive_window.gradient.color2) == 2) {
+      settings->inactive_window.stype = COLOR_STYLE_GRADIENT;
+      settings->inactive_window.gradient.direction = TL_TO_BR;
       update_mask |= BORDER_UPDATE_MASK_INACTIVE;
     }
     else if (sscanf(arguments[i],
              "inactive_color=gradient(top_right=0x%x,bottom_left=0x%x)",
-             &settings->inactive_window.style.gradient.color1,
-             &settings->inactive_window.style.gradient.color2) == 2) {
-      settings->inactive_window.stype = GRADIENT;
-      settings->inactive_window.style.gradient.direction = TOPRIGHT_BOTTOMLEFT;
+             &settings->inactive_window.gradient.color1,
+             &settings->inactive_window.gradient.color2) == 2) {
+      settings->inactive_window.stype = COLOR_STYLE_GRADIENT;
+      settings->inactive_window.gradient.direction = TR_TO_BL;
       update_mask |= BORDER_UPDATE_MASK_INACTIVE;
     }
     else if (sscanf(arguments[i], "width=%f", &settings->border_width) == 1) {


### PR DESCRIPTION
Very initial, incomplete, hardcoded HACK as of right now.

- [x] Work with square borders
- [x] Support top-left to bottom-right corner gradient too
- [ ] (Maybe?) 4 corner gradient—this would be implemented differently
- [x] Commandline option support

Creates a gradient that is clipped to the stroke path as described in the SO thread in #19.

I also noticed frame dropping with Yabai resizing (i.e., it would only have maybe 3 intermediate frames that animate in a choppy manner) (fixed by restarting Yabai) which may or may not be related to this.