### PR TITLE
Feat: Add backgrounds and blur radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ options=(
 	style=round
 	width=6.0
 	hidpi=off
+	blur_radius=0.0
+	show_background=off
 	active_color=0xffe2e2e3
 	inactive_color=0xff414550
 )

--- a/src/border.c
+++ b/src/border.c
@@ -161,7 +161,7 @@ void border_draw(struct border* border) {
       // truly square border
       path_rect = CGRectInset(window_frame, BORDER_TSMN, BORDER_TSMN);
       CGPathAddRect(clip_path, NULL, path_rect);
-    } else {
+    } else if ( !g_settings.show_background ) {
       CGPathAddRoundedRect(clip_path,
                            NULL,
                            CGRectInset(path_rect, 1.0, 1.0),
@@ -204,6 +204,10 @@ void border_draw(struct border* border) {
       if (color_style.stype == COLOR_STYLE_SOLID
          || color_style.stype == COLOR_STYLE_GLOW) {
         CGContextStrokePath(border->context);
+        if (g_settings.show_background) {
+          CGContextAddPath(border->context, stroke_path);
+          CGContextFillPath(border->context);
+        }
       }
       else if (color_style.stype == COLOR_STYLE_GRADIENT) {
         CGContextReplacePathWithStrokedPath(border->context);
@@ -232,6 +236,7 @@ void border_draw(struct border* border) {
                  border->wid,
                  g_settings.border_order,
                  border->target_wid      );
+  SLSSetWindowBackgroundBlurRadius(cid, border->wid, g_settings.blur_radius);
 
   SLSReenableUpdate(cid);
 }

--- a/src/border.h
+++ b/src/border.h
@@ -30,8 +30,10 @@ struct settings {
   struct color_style inactive_window;
 
   float border_width;
+  float blur_radius;
   char border_style;
   bool hidpi;
+  bool show_background;
   int border_order;
 
   bool blacklist_enabled;

--- a/src/parse.c
+++ b/src/parse.c
@@ -104,6 +104,14 @@ uint32_t parse_settings(struct settings* settings, int count, char** arguments) 
     } else if (strcmp(arguments[i], "hidpi=off") == 0) {
       update_mask |= BORDER_UPDATE_MASK_RECREATE_ALL;
       settings->hidpi = false;
+    } else if (strcmp(arguments[i], "show_background=on") == 0) {
+      update_mask |= BORDER_UPDATE_MASK_RECREATE_ALL;
+      settings->show_background = true;
+    } else if (strcmp(arguments[i], "show_background=off") == 0) {
+      update_mask |= BORDER_UPDATE_MASK_RECREATE_ALL;
+      settings->show_background = false;
+    } else if (sscanf(arguments[i], "blur_radius=%f", &settings->blur_radius) == 1) {
+      update_mask |= BORDER_UPDATE_MASK_ALL;
     } else {
       printf("[?] Borders: Invalid argument '%s'\n", arguments[i]);
     }


### PR DESCRIPTION
Adds a pretty basic ability to draw backgrounds behind windows and optionally blur them

![image](https://github.com/FelixKratz/JankyBorders/assets/5733032/8c93d8f9-3e1e-4cb4-a8d1-4da1ec527ebb)
