### PR TITLE
Add border style "none".

### DIFF
--- a/src/border.h
+++ b/src/border.h
@@ -10,6 +10,7 @@
 #define BORDER_ORDER_BELOW -1
 #define BORDER_STYLE_ROUND  'r'
 #define BORDER_STYLE_SQUARE 's'
+#define BORDER_STYLE_NONE 'n'
 #define BORDER_PADDING 8.0
 #define BORDER_TSMN 3.27f
 #define BORDER_TSMW 8.f

--- a/src/parse.c
+++ b/src/parse.c
@@ -108,7 +108,7 @@ uint32_t parse_settings(struct settings* settings, int count, char** arguments) 
       update_mask |= BORDER_UPDATE_MASK_ALL;
     }
     else if (sscanf(arguments[i], "style=%c", &settings->border_style) == 1) {
-      update_mask |= BORDER_UPDATE_MASK_ALL;
+      update_mask |= BORDER_UPDATE_MASK_RECREATE_ALL;
     }
     else if (strcmp(arguments[i], "hidpi=on") == 0) {
       update_mask |= BORDER_UPDATE_MASK_RECREATE_ALL;

--- a/src/windows.c
+++ b/src/windows.c
@@ -36,7 +36,7 @@ bool windows_window_create(struct table* windows, uint32_t wid, uint64_t sid) {
   static char pid_name_buffer[PROC_PIDPATHINFO_MAXSIZE];
   proc_name(pid, pid_name_buffer, sizeof(pid_name_buffer));
 
-  if (pid == g_pid || !app_allowed(&g_settings, pid_name_buffer)) return false;
+  if (pid == g_pid || !app_allowed(&g_settings, pid_name_buffer) || g_settings.border_style == BORDER_STYLE_NONE) return false;
 
   CFArrayRef target_ref = cfarray_of_cfnumbers(&wid,
                                                sizeof(uint32_t),
@@ -355,4 +355,6 @@ void windows_add_existing_windows(struct table* windows) {
   }
   CFRelease(space_list_ref);
   free(space_list);
+
+  windows_determine_and_focus_active_window(windows);
 }


### PR DESCRIPTION
Add border style `none` to disable borders (see #142). This PR also fixes the focused window not being highlighted after startup (and after changing the border style from `none` to `round` or `square`).