### PR TITLE
Ignore windows that ignore window cycling

### DIFF
--- a/src/misc/window.h
+++ b/src/misc/window.h
@@ -3,11 +3,12 @@
 #include "helpers.h"
 #include "space.h"
 
-#define WINDOW_TAG_DOCUMENT (1ULL << 0)
-#define WINDOW_TAG_FLOATING (1ULL << 1)
-#define WINDOW_TAG_ATTACHED (1ULL << 7)
-#define WINDOW_TAG_STICKY   (1ULL << 11)
-#define WINDOW_TAG_MODAL    (1ULL << 31)
+#define WINDOW_TAG_DOCUMENT      (1ULL << 0)
+#define WINDOW_TAG_FLOATING      (1ULL << 1)
+#define WINDOW_TAG_ATTACHED      (1ULL << 7)
+#define WINDOW_TAG_STICKY        (1ULL << 11)
+#define WINDOW_TAG_IGNORES_CYCLE (1ULL << 18)
+#define WINDOW_TAG_MODAL         (1ULL << 31)
 
 static inline bool window_suitable(CFTypeRef iterator) {
   uint64_t tags = SLSWindowIteratorGetTags(iterator);
@@ -16,6 +17,7 @@ static inline bool window_suitable(CFTypeRef iterator) {
   if ((parent_wid == 0)
        && ((attributes & 0x2) || (tags & 0x400000000000000))
        && !(tags & WINDOW_TAG_ATTACHED)
+       && !(tags & WINDOW_TAG_IGNORES_CYCLE)
        && ((tags & WINDOW_TAG_DOCUMENT) || ((tags & WINDOW_TAG_FLOATING)
                                             && (tags & WINDOW_TAG_MODAL)))) {
     return true;


### PR DESCRIPTION
Filters out tooltips and transient UI elements (like JetBrains IDE tooltips) by excluding windows with the kCGSIgnoresCycleTagBit tag.

Solves https://github.com/FelixKratz/JankyBorders/issues/111

# Before
<img width="823" height="205" alt="Screenshot 2025-10-02 at 5 22 12 PM" src="https://github.com/user-attachments/assets/e44d971f-c624-4031-b00d-a6feebc95691" />


# After
<img width="735" height="199" alt="Screenshot 2025-10-02 at 5 24 08 PM" src="https://github.com/user-attachments/assets/e29ac84f-ba16-4f6e-bc1c-382e8aa2b814" />
