### PR TITLE
fix(border): debounce border redraws adaptively to prevent flicker without lag

### DIFF
--- a/src/border.c
+++ b/src/border.c
@@ -257,19 +257,6 @@ void border_update_internal(struct border* border, struct settings* settings) {
   if (disabled_update) SLSReenableUpdate(cid);
 }
 
-static void* border_update_async_proc(void* context) {
-  struct {
-    struct border* border;
-    struct settings settings;
-  }* payload = context;
-
-  pthread_mutex_lock(&payload->border->mutex);
-  border_update_internal(payload->border, &payload->settings);
-  pthread_mutex_unlock(&payload->border->mutex);
-  free(payload);
-  return NULL;
-}
-
 void border_init(struct border* border, int cid) {
   memset(border, 0, sizeof(struct border));
   pthread_mutexattr_t mattr;
@@ -335,31 +322,41 @@ void border_move(struct border* border) {
   });
 }
 
+// Adaptive debounce: a space change triggers a burst of events (unhide, level,
+// reorder, focus) that each cause a redraw and visible flicker, so during a
+// space transition (see border_space_change_begin) collapse bursts with a long
+// debounce; otherwise redraw almost immediately so the border tracks focus.
+#define DEBOUNCE_NORMAL_NS (5 * NSEC_PER_MSEC)
+#define DEBOUNCE_SPACE_NS  (80 * NSEC_PER_MSEC)
+#define SPACE_SETTLE_NS    (500 * NSEC_PER_MSEC)
+
+static uint64_t g_space_change_deadline = 0;
+
+void border_space_change_begin(void) {
+  g_space_change_deadline = dispatch_time(DISPATCH_TIME_NOW, SPACE_SETTLE_NS);
+}
+
 void border_update(struct border* border, bool try_async) {
-  pthread_mutex_lock(&border->mutex);
   struct settings* settings = border_get_settings(border);
-  border_update_internal(border, settings);
-  pthread_mutex_unlock(&border->mutex);
-  return;
+  // __block: captured by reference so the dispatch block can pass a
+  // non-const pointer (plain captures are const inside the block).
+  __block struct settings settings_copy = *settings;
 
-  if (!border->wid || !try_async) {
-    border_update_internal(border, settings);
+  pthread_mutex_lock(&border->mutex);
+  uint64_t gen = ++border->update_generation;
+  pthread_mutex_unlock(&border->mutex);
+
+  uint64_t delay = dispatch_time(DISPATCH_TIME_NOW, 0) < g_space_change_deadline
+      ? DEBOUNCE_SPACE_NS
+      : DEBOUNCE_NORMAL_NS;
+
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay),
+                 dispatch_get_main_queue(), ^{
+    if (gen != border->update_generation) return;  // superseded by a newer update
+    pthread_mutex_lock(&border->mutex);
+    border_update_internal(border, &settings_copy);
     pthread_mutex_unlock(&border->mutex);
-    return;
-  }
-
-  struct payload {
-    struct border* border;
-    struct settings settings;
-  }* payload = malloc(sizeof(struct payload));
-
-  payload->border = border;
-  payload->settings = *settings;
-
-  pthread_t thread;
-  pthread_create(&thread, NULL, border_update_async_proc, payload);
-  pthread_detach(thread);
-  pthread_mutex_unlock(&border->mutex);
+  });
 }
 
 void border_hide(struct border* border) {

--- a/src/border.h
+++ b/src/border.h
@@ -88,6 +88,8 @@ struct border {
   volatile uint32_t external_proxy_wid;
 
   struct settings setting_override;
+
+  uint64_t update_generation;
 };
 
 struct border* border_create();
@@ -95,6 +97,7 @@ void border_destroy(struct border* border);
 
 void border_move(struct border* border);
 void border_update(struct border* border, bool try_async);
+void border_space_change_begin(void);
 void border_hide(struct border* border);
 void border_unhide(struct border* border);
 

--- a/src/events.c
+++ b/src/events.c
@@ -101,6 +101,9 @@ static void front_app_handler() {
 }
 
 static void space_handler() {
+  // Open the transition window so border_update uses the long (anti-flicker)
+  // debounce for the burst of events the space switch animation produces.
+  border_space_change_begin();
   // Not all native-fullscreen windows have yet updated their space id...
   DELAY_ASYNC_EXEC_ON_MAIN_THREAD(20000, {
     windows_draw_borders_on_current_spaces(&g_windows);


### PR DESCRIPTION
## Problem
When switching spaces with yabai's instant (scripting-addition) switch, the focused window's border visibly flickers — it gets redrawn several times in quick succession. This does not happen with macOS's native (animated) space switching. Reported in #79.

## Root cause
On a space change, a window is hit by a burst of events — `Unhide`, `Level`, `Reorder`, and `Focus` — each of which calls `border_update()`, and each redraw is a visible flash. The focused border is therefore repainted ~4-5 times within ~50ms.

## Fix
An adaptive per-border debounce in `border_update()`:

- A constant 80ms debounce (my first attempt) kills the flicker but makes the border visibly **lag behind fast focus changes**, because every update reschedules the wait. So the delay is now context-dependent:
- borders already receives `EVENT_SPACE_CHANGE` (`space_handler` in `events.c`); when it fires, a **500ms transition window** opens.
- Inside the window, updates are debounced by **80ms**, collapsing the burst into a single redraw with the final state (anti-flicker).
- Outside the window, updates are debounced by only **5ms**, so the border tracks focus changes almost instantly.
- Each border keeps an incrementing `update_generation` counter; a newer request supersedes older scheduled ones in both modes.

Also drops the unreachable async path left in `border_update()` (`border_update_async_proc`).

Tested with yabai instant space switching and fast window cycling: no flicker on space change, border tracks focus immediately otherwise.

Fixes #79